### PR TITLE
Use public actions and check dependencies

### DIFF
--- a/.github/workflows/js-checks.yml
+++ b/.github/workflows/js-checks.yml
@@ -9,15 +9,5 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  run-checks:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version-file: .nvmrc
-      - run: npm ci
-      - run: npm run format:check
-      - run: npm run lint
-      - run: npm run knip
-      - run: npm test
+  run-checks-and-tests:
+    uses: bloq/actions/.github/workflows/js-checks.yml@v1

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -10,10 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version-file: .nvmrc
-      - run: npm ci
-      - uses: JS-DevTools/npm-publish@v3
+      - uses: bloq/actions/publish-to-npm@v1
         with:
           token: ${{ secrets.NPM_TOKEN }}

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,1 +1,2 @@
-npm test
+npm run test
+npm run deps:check

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
   "repository": "hemilabs/better-sort-package-json",
   "scripts": {
     "coverage": "c8 npm test",
+    "deps:check": "knip",
     "format:check": "prettier --check .",
-    "knip": "knip",
     "lint": "eslint --cache .",
     "prepare": "husky",
     "test": "mocha"


### PR DESCRIPTION
This PR replaces the current custom workflows with the public actions published at Bloq.

In addition, a check for missing/extra dependencies was added to the pre-push git hook. 